### PR TITLE
Add AppLC team to OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,6 +11,11 @@ approvers:
 - elgnay
 - skeeey
 - xiangjingli
+- lennysgarage
+- chenz4027
+- mikeshng
+- rokej
+- philipwu08
 reviewers:
 - jnpacker
 - itdove
@@ -24,3 +29,8 @@ reviewers:
 - elgnay
 - skeeey
 - xiangjingli
+- lennysgarage
+- chenz4027
+- mikeshng
+- rokej
+- philipwu08


### PR DESCRIPTION
This PR is to add the Applifecycle team to the list of approvers & reviewers.