### PR TITLE
ACM-4440 Revert go to 1.19

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.20-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.19-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/provider-credential-controller
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/provider-credential-controller
 
-go 1.20
+go 1.19
 
 replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // CVE-2021-43565
 


### PR DESCRIPTION
Cachito's internal workers that are required for the downstream of provider-credential-controller only support upto go 1.19.

Addresses:
 - https://issues.redhat.com/browse/ACM-4440