### PR TITLE
Add leader election settings

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	"github.com/stolostron/provider-credential-controller/controllers/providercredential"
 	"go.uber.org/zap/zapcore"
@@ -34,14 +35,47 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var leaderElectionLeaseDuration time.Duration
+	var leaderElectionRenewDeadline time.Duration
+	var leaderElectionRetryPeriod time.Duration
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.DurationVar(
+		&leaderElectionLeaseDuration,
+		"leader-election-lease-duration",
+		137*time.Second,
+		"The duration that non-leader candidates will wait after observing a leadership "+
+			"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+			"slot. This is effectively the maximum duration that a leader can be stopped "+
+			"before it is replaced by another candidate. This is only applicable if leader "+
+			"election is enabled.",
+	)
+	flag.DurationVar(
+		&leaderElectionRenewDeadline,
+		"leader-election-renew-deadline",
+		107*time.Second,
+		"The interval between attempts by the acting master to renew a leadership slot "+
+			"before it stops leading. This must be less than or equal to the lease duration. "+
+			"This is only applicable if leader election is enabled.",
+	)
+	flag.DurationVar(
+		&leaderElectionRetryPeriod,
+		"leader-election-retry-period",
+		26*time.Second,
+		"The duration the clients should wait between attempting acquisition and renewal "+
+			"of a leadership. This is only applicable if leader election is enabled.",
+	)
 	flag.Parse()
 
 	// To run in debug change zapcore.InfoLevel to zapcore.DebugLevel
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(zapcore.InfoLevel)))
+
+	setupLog.Info("Leader election settings", "enableLeaderElection", enableLeaderElection,
+		"leaseDuration", leaderElectionLeaseDuration,
+		"renewDeadline", leaderElectionRenewDeadline,
+		"retryPeriod", leaderElectionRetryPeriod)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
@@ -57,6 +91,9 @@ func main() {
 		),
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: "provider-credential-controller.open-cluster-management.io",
+		LeaseDuration:    &leaderElectionLeaseDuration,
+		RenewDeadline:    &leaderElectionRenewDeadline,
+		RetryPeriod:      &leaderElectionRetryPeriod,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/cmd/oldproviderconnection/main.go
+++ b/cmd/oldproviderconnection/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	"github.com/stolostron/provider-credential-controller/controllers/oldproviderconnection"
 	"go.uber.org/zap/zapcore"
@@ -34,14 +35,47 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var leaderElectionLeaseDuration time.Duration
+	var leaderElectionRenewDeadline time.Duration
+	var leaderElectionRetryPeriod time.Duration
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8383", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.DurationVar(
+		&leaderElectionLeaseDuration,
+		"leader-election-lease-duration",
+		137*time.Second,
+		"The duration that non-leader candidates will wait after observing a leadership "+
+			"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+			"slot. This is effectively the maximum duration that a leader can be stopped "+
+			"before it is replaced by another candidate. This is only applicable if leader "+
+			"election is enabled.",
+	)
+	flag.DurationVar(
+		&leaderElectionRenewDeadline,
+		"leader-election-renew-deadline",
+		107*time.Second,
+		"The interval between attempts by the acting master to renew a leadership slot "+
+			"before it stops leading. This must be less than or equal to the lease duration. "+
+			"This is only applicable if leader election is enabled.",
+	)
+	flag.DurationVar(
+		&leaderElectionRetryPeriod,
+		"leader-election-retry-period",
+		26*time.Second,
+		"The duration the clients should wait between attempting acquisition and renewal "+
+			"of a leadership. This is only applicable if leader election is enabled.",
+	)
 	flag.Parse()
 
 	// To run in debug change zapcore.InfoLevel to zapcore.DebugLevel
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(zapcore.InfoLevel)))
+
+	setupLog.Info("Leader election settings", "enableLeaderElection", enableLeaderElection,
+		"leaseDuration", leaderElectionLeaseDuration,
+		"renewDeadline", leaderElectionRenewDeadline,
+		"retryPeriod", leaderElectionRetryPeriod)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
@@ -56,6 +90,9 @@ func main() {
 		),
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: "old-provider-connection-controller.open-cluster-management.io",
+		LeaseDuration:    &leaderElectionLeaseDuration,
+		RenewDeadline:    &leaderElectionRenewDeadline,
+		RetryPeriod:      &leaderElectionRetryPeriod,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/deploy/controller/deployment.yaml
+++ b/deploy/controller/deployment.yaml
@@ -32,6 +32,9 @@ spec:
       - command:
         - "./manager"
         - "-enable-leader-election"
+        - "--leader-election-lease-duration=137s"
+        - "--leader-election-renew-deadline=107s"
+        - "--leader-election-retry-period=26s"
         image: registry.ci.openshift.org/stolostron/2.3:provider-credential-controller
         imagePullPolicy: Always
         name: provider-credential-controller
@@ -52,6 +55,9 @@ spec:
       - command:
         - "./old-provider-connection"
         - "-enable-leader-election"
+        - "--leader-election-lease-duration=137s"
+        - "--leader-election-renew-deadline=107s"
+        - "--leader-election-retry-period=26s"
         image: registry.ci.openshift.org/stolostron/2.3:provider-credential-controller
         imagePullPolicy: Always
         name: old-provider-connection

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,10 @@
 sonar.projectKey=open-cluster-management_provider-credential-controller
 sonar.projectName=provider-credential-controller
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,**/main.go
+sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,**/main.go**,**/cmd/**
 sonar.tests=.
 sonar.test.inclusions=**/provider-credential-controller_test.go
-sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**
+sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**,**/cmd/**
 sonar.go.tests.reportPaths=report.json
 sonar.go.coverage.reportPaths=coverage.out
 sonar.externalIssuesReportPaths=gosec.json


### PR DESCRIPTION
This PR adds the leader election settings with default values to both controllers:
``` 
--leader-election-lease-duration=136s
--leader-election-renew-deadline=107s
--leader-election-retry-period=26s
```

Updates sonar properties to ignore the controllers `main.go`