### PR TITLE
Add repository url label to container images

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -8,6 +8,7 @@ RUN make -f Makefile.prow compile-konflux
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
+      url="https://github.com/stolostron/provider-credential-controller" \
     name="provider-credential-controller" \
     com.redhat.component="provider-credential-controller" \
     description="Provider credential controller" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** backplane-2.10

**Components affected:** provider-credential-controller

**Branch details:** provider-credential-controller (branch: backplane-2.10)

**Label added:**
- url: https://github.com/stolostron/provider-credential-controller

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.