### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for provider-credential-controller-mce-29

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -8,7 +8,8 @@ RUN make -f Makefile.prow compile-konflux
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
-    name="provider-credential-controller" \
+    name="multicluster-engine/provider-credential-controller-rhel9" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
     com.redhat.component="provider-credential-controller" \
     description="Provider credential controller" \
     maintainer="acm-contact@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
