### PR TITLE
upgrade Dockerfile to go 1.24

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.23-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/provider-credential-controller
 COPY . .

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
 
 WORKDIR /go/src/github.com/stolostron/provider-credential-controller
 COPY . .


### PR DESCRIPTION
konflux image build failed with an error 
```
Go compliance shim [1658] [rhel-9-golang-1.23][openshift-golang-builder]: final command line arguments: "build" "-o" "build/_output/manager" "./cmd/manager/main.go" 

Go compliance shim [1658] [rhel-9-golang-1.23][openshift-golang-builder]: invoking real go binary
go: go.mod requires go >= 1.24.0 (running go 1.23.9; GOTOOLCHAIN=local)
Go compliance shim [1658] [rhel-9-golang-1.23][openshift-golang-builder]: Exited with: 1
make: *** [Makefile.prow:21: compile-konflux] Error 1
```