### PR TITLE
Add FIPS support flag for HYPBLD-844

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -3,7 +3,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS bui
 WORKDIR /go/src/github.com/stolostron/provider-credential-controller
 COPY . .
 
-RUN make -f Makefile.prow compile-konflux
+RUN GOEXPERIMENT=strictfipsruntime make -f Makefile.prow compile-konflux
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Apply GOEXPERIMENT=strictfipsruntime to Dockerfile.rhtap for FIPS support.  (Note, CGO_ENABLED=1 is already defined in the build command of Makefile.prow.)

JIRA: HYPBLD-844